### PR TITLE
feat: add exit hook to cancel order when process terminated by user

### DIFF
--- a/__tests__/binance-oco.test.ts
+++ b/__tests__/binance-oco.test.ts
@@ -1073,4 +1073,193 @@ describe("orders", () => {
       });
     });
   });
+
+  describe("exit hook", () => {
+    test("exit hook: order placed not filled - cancels order", done => {
+      binance.default.mockImplementation(() => ({
+        avgPrice: bnbbtcAvgPrice,
+        accountInfo: mockAccountInfo,
+        exchangeInfo: bnbbtcExchangeInfo,
+        order: mockOrder,
+        orderOco: mockOrderOco,
+        cancelOrder: mockCancel,
+        orderTest: jest.fn(),
+        getOrder: jest.fn(() => Promise.resolve({ status: "NEW" })),
+        prices: bnbbtcPrices,
+        ws: {
+          trades: jest.fn(),
+          user: jest.fn()
+        }
+      }));
+
+      let exitHook = (cancel: Function) => {
+        // this must work asychronously hence the wait
+        setImmediate(async () => {
+          await cancel();
+          expect(mockCancel).toBeCalledWith({ symbol: "BNBBTC", orderId: "1" });
+          done();
+        });
+      };
+
+      expect(
+        binanceOco(
+          {
+            pair: "BNBBTC",
+            amount: 1,
+            buyPrice: 0.002,
+            stopPrice: 0.001,
+            targetPrice: 0.003
+          },
+          exitHook
+        )
+      ).resolves.not.toBeDefined();
+    });
+
+    test("exit hook: immediate order fill - do not cancel stop order", done => {
+      const mockOrder = jest.fn(() => ({
+        orderId: "1",
+        status: "FILLED",
+        fills: [
+          {
+            commissionAsset: "BNB"
+          }
+        ]
+      }));
+
+      binance.default.mockImplementation(() => ({
+        avgPrice: bnbbtcAvgPrice,
+        accountInfo: mockAccountInfo,
+        exchangeInfo: bnbbtcExchangeInfo,
+        order: mockOrder,
+        orderOco: mockOrderOco,
+        cancelOrder: mockCancel,
+        orderTest: jest.fn(),
+        getOrder: jest.fn(() => Promise.resolve({ status: "NEW" })),
+        prices: bnbbtcPrices,
+        tradeFee: jest.fn(() => ({
+          tradeFee: [
+            {
+              symbol: "BNBBTC",
+              maker: 0.001,
+              taker: 0.001
+            }
+          ]
+        })),
+        ws: {
+          trades: jest.fn(),
+          user: jest.fn()
+        }
+      }));
+
+      let exitHook = (cancel: Function) => {
+        // this must work asychronously hence the wait
+        setImmediate(async () => {
+          await cancel();
+          expect(mockCancel).not.toBeCalled();
+          done();
+        });
+      };
+
+      expect(
+        binanceOco(
+          {
+            pair: "BNBBTC",
+            amount: 1,
+            buyPrice: 0.002,
+            stopPrice: 0.001,
+            targetPrice: 0.003
+          },
+          exitHook
+        )
+      ).resolves.not.toBeDefined();
+    });
+
+    test("exit hook: order filled via order status - do not cancel stop order", done => {
+      binance.default.mockImplementation(() => ({
+        avgPrice: bnbbtcAvgPrice,
+        accountInfo: mockAccountInfo,
+        exchangeInfo: bnbbtcExchangeInfo,
+        order: mockOrder,
+        orderOco: mockOrderOco,
+        cancelOrder: mockCancel,
+        orderTest: jest.fn(),
+        getOrder: jest.fn(() => Promise.resolve({ status: "FILLED" })),
+        prices: bnbbtcPrices,
+        ws: {
+          trades: jest.fn(),
+          user: jest.fn()
+        }
+      }));
+
+      let exitHook = (cancel: Function) => {
+        // this must work asychronously hence the wait
+        setImmediate(async () => {
+          await cancel();
+          expect(mockCancel).not.toBeCalled();
+          done();
+        });
+      };
+
+      expect(
+        binanceOco(
+          {
+            pair: "BNBBTC",
+            amount: 1,
+            buyPrice: 0.002,
+            stopPrice: 0.001,
+            targetPrice: 0.003
+          },
+          exitHook
+        )
+      ).resolves.not.toBeDefined();
+    });
+
+    test("exit hook: non market order filled via user update - do not cancel stop order", done => {
+      // this is a fill via user data
+      binance.default.mockImplementation(() => ({
+        avgPrice: bnbbtcAvgPrice,
+        accountInfo: mockAccountInfo,
+        exchangeInfo: bnbbtcExchangeInfo,
+        order: mockOrder,
+        orderOco: mockOrderOco,
+        cancelOrder: mockCancel,
+        orderTest: jest.fn(),
+        getOrder: jest.fn(() => Promise.resolve({ status: "NEW" })),
+        prices: bnbbtcPrices,
+        ws: {
+          trades: jest.fn(),
+          user: jest.fn(cb => {
+            cb({
+              eventType: "executionReport",
+              orderId: "1",
+              commissionAsset: "BNB",
+              orderStatus: "FILLED"
+            });
+          })
+        }
+      }));
+
+      let exitHook = (cancel: Function) => {
+        // this must work asychronously hence the wait
+        setImmediate(async () => {
+          await cancel();
+          expect(mockCancel).not.toBeCalled();
+          done();
+        });
+      };
+
+      expect(
+        binanceOco(
+          {
+            pair: "BNBBTC",
+            amount: 1,
+            buyPrice: 0.002,
+            stopPrice: 0.001,
+            targetPrice: 0.003
+          },
+          exitHook
+        )
+      ).resolves.not.toBeDefined();
+    });
+  });
 });

--- a/src/binance-oco.ts
+++ b/src/binance-oco.ts
@@ -4,6 +4,7 @@ import Binance, {
   ExecutionReport,
   Message,
   NewOrder,
+  Order,
   SymbolLotSizeFilter,
   SymbolMinNotionalFilter,
   SymbolPercentPriceFilter,
@@ -55,18 +56,21 @@ const schema = Joi.object()
   .with("stopLimitPrice", "stopPrice")
   .with("scaleOutAmount", "targetPrice");
 
-export const binanceOco = async (options: {
-  pair: string;
-  amount: string;
-  buyPrice?: string;
-  buyLimitPrice?: string;
-  cancelPrice?: string;
-  stopPrice?: string;
-  stopLimitPrice?: string;
-  targetPrice?: string;
-  scaleOutAmount?: string;
-  nonBnbFees?: boolean;
-}): Promise<void> => {
+export const binanceOco = async (
+  options: {
+    pair: string;
+    amount: string;
+    buyPrice?: string;
+    buyLimitPrice?: string;
+    cancelPrice?: string;
+    stopPrice?: string;
+    stopLimitPrice?: string;
+    targetPrice?: string;
+    scaleOutAmount?: string;
+    nonBnbFees?: boolean;
+  },
+  exitHook?: Function
+): Promise<void> => {
   const result = Joi.validate(options, schema);
   if (result.error !== null) {
     throw result.error;
@@ -447,7 +451,7 @@ export const binanceOco = async (options: {
   }
 
   if (typeof buyPrice !== "undefined" && new BigNumber(buyPrice).gte(0)) {
-    let response;
+    let response: any
     try {
       if (new BigNumber(buyPrice).isZero()) {
         response = await binance.order({
@@ -491,14 +495,31 @@ export const binanceOco = async (options: {
       debug("Buy response: %o", response);
       debug(`order id: ${response.orderId}`);
 
+      let orderFilled = (response.status == "FILLED");
+      // Exit hook to safely cancel order
+      if (exitHook) {
+        exitHook(async () => {
+          debug("Exit hook fired")
+          var order = response as Order
+          if (order) {
+            if (!orderFilled) {
+              await cancelOrderAsync(pair, order.orderId);
+            }
+          }
+        })
+      }
+
       let commissionAsset = "";
       if (response.status !== "FILLED") {
-        commissionAsset = await waitForBuyOrderFill(response.orderId).finally(
+        commissionAsset = await waitForBuyOrderFill(response.orderId)
+        .finally(
           disconnect
         );
       } else if (response.fills && response.fills.length > 0) {
         commissionAsset = response.fills[0].commissionAsset;
       }
+      orderFilled = true;
+
 
       if (stopPrice || targetPrice) {
         await adjustSellAmountsForCommission(commissionAsset, stepSize);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,38 +86,45 @@ const {
 
 const debug = require("debug")("binance-oco");
 
-const exitHooks = (cancel: Function) => {
-
+const exitHooks = async (cancel: Function): Promise<void> => {
   // safety mechanism - cancel order if process is interrupted.
-  process.once('SIGINT', async (code) => {
-    debug(`handled script interrupt - code ${code}.`);
-    await cancel()
-  });
+  process.once(
+    "SIGINT",
+    async (code): Promise<void> => {
+      debug(`handled script interrupt - code ${code}.`);
+      await cancel();
+    }
+  );
 
-  process.once('SIGTERM', async (code) => {
-    debug(`handled script interrupt - code ${code}.`);
-    await cancel()
-  });
-}
+  process.once(
+    "SIGTERM",
+    async (code): Promise<void> => {
+      debug(`handled script interrupt - code ${code}.`);
+      await cancel();
+    }
+  );
+};
 
 (async (): Promise<void> => {
   try {
-    await binanceOco({
-      pair: pair.toUpperCase(),
-      amount,
-      buyPrice,
-      buyLimitPrice,
-      stopPrice,
-      stopLimitPrice,
-      targetPrice,
-      cancelPrice,
-      scaleOutAmount,
-      nonBnbFees
-    }, exitHooks);
+    await binanceOco(
+      {
+        pair: pair.toUpperCase(),
+        amount,
+        buyPrice,
+        buyLimitPrice,
+        stopPrice,
+        stopLimitPrice,
+        targetPrice,
+        cancelPrice,
+        scaleOutAmount,
+        nonBnbFees
+      },
+      exitHooks
+    );
     process.exit(0);
   } catch (err) {
     debug(err.message);
     process.exit(1);
   }
-
 })();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,6 +86,20 @@ const {
 
 const debug = require("debug")("binance-oco");
 
+const exitHooks = (cancel: Function) => {
+
+  // safety mechanism - cancel order if process is interrupted.
+  process.once('SIGINT', async (code) => {
+    debug(`handled script interrupt - code ${code}.`);
+    await cancel()
+  });
+
+  process.once('SIGTERM', async (code) => {
+    debug(`handled script interrupt - code ${code}.`);
+    await cancel()
+  });
+}
+
 (async (): Promise<void> => {
   try {
     await binanceOco({
@@ -99,10 +113,11 @@ const debug = require("debug")("binance-oco");
       cancelPrice,
       scaleOutAmount,
       nonBnbFees
-    });
+    }, exitHooks);
     process.exit(0);
   } catch (err) {
     debug(err.message);
     process.exit(1);
   }
+
 })();


### PR DESCRIPTION
order is not cancelled if already filled.

Ran following tests:
PLACE A STOP-LIMIT ORDER -> CANCEL - PASS
PLACE A STOP-LIMIT ORDER -> TRIGGER -> OCO - PASS
PLACE A LIMIT ORDER -> CANCEL - PASS
PLACE A LIMIT ORDER -> TRIGGER -> OCO - PASS